### PR TITLE
updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Distrax can be installed with pip directly from GitHub:
 
 or from PyPI:
 
-`pip install distrax`
+`pip install distrax`| `pip3 install distrax`
 
 To run the tests or
 [examples](https://github.com/deepmind/distrax/tree/master/examples) you will


### PR DESCRIPTION
Hello there,

```
adwaitnaik@Mackbook-Air-Adwait ~ % pip install distrax
```
Error: 
```
ERROR: Could not find a version that satisfies the requirement distrax (from versions: none)
ERROR: No matching distribution found for distrax
```

using python3

```
adwaitnaik@Mackbook-Air-Adwait ~ % pip3 install distrax
Collecting distrax
  Downloading distrax-0.0.1-py3-none-any.whl (196 kB)
     |████████████████████████████████| 196 kB 1.7 MB/s 
Collecting jaxlib>=0.1.37
  Downloading jaxlib-0.1.65-cp39-none-macosx_10_9_x86_64.whl (43.2 MB)
     |████████████████████████████████| 43.2 MB 5.9 MB/s 
Collecting chex>=0.0.5
  Downloading chex-0.0.6-py3-none-any.whl (51 kB)
     |████████████████████████████████| 51 kB 665 kB/s 
Requirement already satisfied: numpy>=1.18.0 in ./Library/Python/3.9/lib/python/site-packages (from distrax) (1.19.5)
Collecting tensorflow-probability>=0.12.1
  Downloading tensorflow_probability-0.12.1-py2.py3-none-any.whl (4.8 MB)
     |████████████████████████████████| 4.8 MB 13.8 MB/s 
Collecting absl-py>=0.9.0
  Downloading absl_py-0.12.0-py3-none-any.whl (129 kB)
     |████████████████████████████████| 129 kB 7.6 MB/s 
Collecting jax<=0.2.11
  Downloading jax-0.2.11.tar.gz (596 kB)
     |████████████████████████████████| 596 kB 8.9 MB/s 
Requirement already satisfied: six in /usr/local/Cellar/protobuf/3.14.0/libexec/lib/python3.9/site-packages (from absl-py>=0.9.0->distrax) (1.15.0)
Collecting toolz>=0.9.0
  Downloading toolz-0.11.1-py3-none-any.whl (55 kB)
     |████████████████████████████████| 55 kB 5.1 MB/s 
Collecting dm-tree>=0.1.5
  Downloading dm_tree-0.1.6-cp39-cp39-macosx_10_14_x86_64.whl (95 kB)
     |████████████████████████████████| 95 kB 3.9 MB/s 
Collecting opt_einsum
  Downloading opt_einsum-3.3.0-py3-none-any.whl (65 kB)
     |████████████████████████████████| 65 kB 5.1 MB/s 
Collecting flatbuffers
  Downloading flatbuffers-1.12-py2.py3-none-any.whl (15 kB)
Requirement already satisfied: scipy in /usr/local/lib/python3.9/site-packages (from jaxlib>=0.1.37->distrax) (1.6.0)
Collecting decorator
  Downloading decorator-5.0.6-py3-none-any.whl (8.8 kB)
Collecting cloudpickle>=1.3
  Downloading cloudpickle-1.6.0-py3-none-any.whl (23 kB)
Collecting gast>=0.3.2
  Downloading gast-0.4.0-py3-none-any.whl (9.8 kB)
Building wheels for collected packages: jax
  Building wheel for jax (setup.py) ... done
  Created wheel for jax: filename=jax-0.2.11-py3-none-any.whl size=687527 sha256=f3528b2c81cd7d34a2daefc6097b681caebf600be21656529205991b12768a36
  Stored in directory: /Users/adwaitnaik/Library/Caches/pip/wheels/d8/15/ea/44a9ea3973902dd5ac54b18560873a4856fbf00f7a353ac6d1
```