### PR TITLE
bump numpy version

### DIFF
--- a/distrax/__init__.py
+++ b/distrax/__init__.py
@@ -87,7 +87,7 @@ from distrax._src.utils.monte_carlo import mc_estimate_kl_with_reparameterized
 from distrax._src.utils.monte_carlo import mc_estimate_mode
 from distrax._src.utils.transformations import register_inverse
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = (
     "as_bijector",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,5 +2,5 @@ absl-py>=0.9.0
 chex>=0.0.7
 jax>=0.1.55
 jaxlib>=0.1.67
-numpy>=1.18.0,<1.23
+numpy>=1.18.0,<1.24
 tensorflow-probability>=0.15.0


### PR DESCRIPTION
Closes #234. Would be useful to get in because TensorFlow 2.12.0 is compiled with a newer version of NumPy.